### PR TITLE
Add support for whitelisting IP subnets

### DIFF
--- a/vpn-fix
+++ b/vpn-fix
@@ -25,7 +25,7 @@ ip_whitelist=()
 
 for host in ${host_whitelist[*]}
 do
-  if [[ $host =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  if [[ $host =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(|\/[0-9]+)$ ]]; then
     echo "Adding $host to whitelist"
     ip_whitelist+=($host)
   else
@@ -41,5 +41,9 @@ done
 
 for address in ${ip_whitelist[*]}
 do
-  route add $address -interface ppp0
+  if [[ $address =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\/[0-9]+$ ]]; then
+    route add -net $addresss -interface pp0
+  else
+    route add $address -interface ppp0
+  fi
 done

--- a/whitelist.txt.sample
+++ b/whitelist.txt.sample
@@ -2,3 +2,4 @@ nearform.com
 github.com
 1.2.3.4
 5.6.7.8
+10.0.0.0/16


### PR DESCRIPTION
This allows you to whitelist an entire IP subnet. This can be useful when, for example, you spend a lot of time SSHing into a lot of EC2 instances in a VPC.